### PR TITLE
Corrected the license to be LogRhythm MIT and adjusted the README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Robert Weber
+Copyright (c) 2014 LogRhythm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ AlarmClock
 ==========
 This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost for the client compared to using StopWatch or std::chrono.
 
-The implementation of AlarmClock was made to be  as accurate as possible, with the assumption that low CPU usage and cheap, CPU wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
+The implementation of AlarmClock was made to be  as accurate as possible, with the assumption that low CPU usage and cheap, CPU-wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
 
-Common expiration time overhead ranged from 50 - 150 microseconds on the current testing platform when the Alarm clock was checked for expiration in a continous loop. (which normally is not a good usage pattern)
+Common expiration time overhead ranged from 50 - 150 microseconds on the current testing platform when the Alarm clock was checked for expiration in a continuous loop (which normally is not a good usage pattern).
 
 The API usage can be found in: [[AlarmClock.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/AlarmClock.h) and in [[AlarmClockTest.cpp]](https://github.com/LogRhythm/StopWatch/blob/master/test/AlarmClockTest.cpp)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ StopWatch
 A timer class in C++ which wraps the std::chrono API, with the purpose of retrieving elapsed time since creation of the object or since the timing was restarted. 
 Measurements are available in microseconds, milliseconds and seconds.
 
-The API can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp)
+The API can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp).
 
 
 ThreadSafeStopWatch

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ StopWatch
 A timer class in C++ which wraps the std::chrono API, with the purpose of retrieving elapsed time since creation of the object or since the timing was restarted. 
 Measurements are available in microseconds, milliseconds and seconds
 
+The API  can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp)
+
 
 ThreadSafeStopWatch
 ===================

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ StopWatch
 =========
 
 A timer class in C++ which wraps the std::chrono API, with the purpose of retrieving elapsed time since creation of the object or since the timing was restarted. 
-Measurements are available in microseconds, milliseconds and seconds
+Measurements are available in microseconds, milliseconds and seconds.
 
 The API can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 AlarmClock
 ==========
-This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost compared to calling to StopWatch or to std::chrono.
-This utility strives to be as accurate as possible but with the assumption that low CPU usage and cheap, CPU,  API calls are more important than absolute accuracy in terms of expiration. 
+This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost compared using StopWatch or std::chrono.
+This utility strives to be as accurate as possible, with the assumption that low CPU usage and cheap, CPU wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
 
-Common expiration time overhead 50 - 150 microseconds on the current testing platform if the Alarm clock would be checked for expiration in a continous loop. (which normally is not a good usage pattern)
+Common expiration time overhead ranged from 50 - 150 microseconds on the current testing platform when the Alarm clock was checked for expiration in a continous loop. (which normally is not a good usage pattern)
 
 The API usage can be found in: [[AlarmClock.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/AlarmClock.h) and in [[AlarmClockTest.cpp]](https://github.com/LogRhythm/StopWatch/blob/master/test/AlarmClockTest.cpp)
 
@@ -12,11 +12,12 @@ The API usage can be found in: [[AlarmClock.h]](https://github.com/LogRhythm/Sto
 StopWatch
 =========
 
-A timer class in C++ which wraps the std::chrono APIs for retrieving how much time has elapsed in microseconds, milliseconds and seconds
+A timer class in C++ which wraps the std::chrono API, with the purpose of retrieving elapsed time since creation of the object or since the timing was restarted. 
+Measurements are available in microseconds, milliseconds and seconds
 
 
 ThreadSafeStopWatch
 ===================
 
-A replacement for `thread_local StopWatch` for platforms that do not have the `thread_local` keyword accessible. It implements the `thread_local`  through a `lazy-barber` map access solution.
-If `thread_local` is available on your platform then  `thread_local StopWatch` is likely a better choice than `ThreadSafeStopWatch`
+A replacement for `thread_local StopWatch` on platforms that do not have the `thread_local` keyword accessible. It implements the `thread_local`  through a `lazy-barber` map access solution.
+If `thread_local` is available on your platform then  `thread_local StopWatch` is likely a better choice than using the`ThreadSafeStopWatch`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 
 AlarmClock
 ==========
-This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost compared using StopWatch or std::chrono.
-This utility strives to be as accurate as possible, with the assumption that low CPU usage and cheap, CPU wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
+This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost for the client compared to using StopWatch or std::chrono.
+
+The implementation of AlarmClock was made to be  as accurate as possible, with the assumption that low CPU usage and cheap, CPU wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
 
 Common expiration time overhead ranged from 50 - 150 microseconds on the current testing platform when the Alarm clock was checked for expiration in a continous loop. (which normally is not a good usage pattern)
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ AlarmClock
 ==========
 This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost for the client compared to using StopWatch or std::chrono.
 
-The implementation of AlarmClock was made to be  as accurate as possible, with the assumption that low CPU usage and cheap, CPU-wise,  API calls are more important than absolute accuracy in terms of some extra microseconds of expiration overhead. 
+The implementation of AlarmClock was made to be as accurate and efficient as possible. The focus is on low CPU consumption, with the tradeoff of less CPU usage resulting in a less accurate expiration capability. 
+ 
 
-Common expiration time overhead ranged from 50 - 150 microseconds on the current testing platform when the Alarm clock was checked for expiration in a continuous loop (which normally is not a good usage pattern).
+Expiration time overhead ranges from 50 - 150 microseconds on the current testing platform, when the Alarm clock is checked for expiration in a continuous loop (which normally is not a good usage pattern).
 
 The API usage can be found in: [[AlarmClock.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/AlarmClock.h) and in [[AlarmClockTest.cpp]](https://github.com/LogRhythm/StopWatch/blob/master/test/AlarmClockTest.cpp)
 
@@ -16,11 +17,11 @@ StopWatch
 A timer class in C++ which wraps the std::chrono API, with the purpose of retrieving elapsed time since creation of the object or since the timing was restarted. 
 Measurements are available in microseconds, milliseconds and seconds
 
-The API  can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp)
+The API can be found in [[StopWatch.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/StopWatch.h) and example usage can be found in the [[tests]](https://github.com/LogRhythm/StopWatch/blob/master/test/ToolsTestStopWatch.cpp)
 
 
 ThreadSafeStopWatch
 ===================
 
-A replacement for `thread_local StopWatch` on platforms that do not have the `thread_local` keyword accessible. It implements the `thread_local`  through a `lazy-barber` map access solution.
-If `thread_local` is available on your platform then  `thread_local StopWatch` is likely a better choice than using the`ThreadSafeStopWatch`
+A replacement for `thread_local StopWatch` on platforms that do not have the `thread_local` keyword accessible. It implements the `thread_local` through a `lazy-barber` map access solution.
+If `thread_local` is available on your platform then `thread_local StopWatch` is likely a better choice than using the`ThreadSafeStopWatch`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
+
+AlarmClock
+==========
+This gives the option to query whether a specified time period has expired. The utility is made to have a very low CPU clock cycle cost compared to calling to StopWatch or to std::chrono.
+This utility strives to be as accurate as possible but with the assumption that low CPU usage and cheap, CPU,  API calls are more important than absolute accuracy in terms of expiration. 
+
+Common expiration time overhead 50 - 150 microseconds on the current testing platform if the Alarm clock would be checked for expiration in a continous loop. (which normally is not a good usage pattern)
+
+The API usage can be found in: [[AlarmClock.h]](https://github.com/LogRhythm/StopWatch/blob/master/src/AlarmClock.h) and in [[AlarmClockTest.cpp]](https://github.com/LogRhythm/StopWatch/blob/master/test/AlarmClockTest.cpp)
+
+
 StopWatch
 =========
 
-A timer class in C++
+A timer class in C++ which wraps the std::chrono APIs for retrieving how much time has elapsed in microseconds, milliseconds and seconds
+
+
+ThreadSafeStopWatch
+===================
+
+A replacement for `thread_local StopWatch` for platforms that do not have the `thread_local` keyword accessible. It implements the `thread_local`  through a `lazy-barber` map access solution.
+If `thread_local` is available on your platform then  `thread_local StopWatch` is likely a better choice than `ThreadSafeStopWatch`


### PR DESCRIPTION
This pull request corrects the LogRhythm LICENSE and improves the Readme.

The README can best be read at: https://github.com/KjellKod/StopWatch-1/blob/LogRhythm_OpenSource_Compliance/README.md