### PR TITLE
Time stats

### DIFF
--- a/src/TimeStats.cpp
+++ b/src/TimeStats.cpp
@@ -1,0 +1,51 @@
+#include "TimeStats.h"
+#include <limits>
+#include <algorithm>
+
+TimeStats::TimeStats() :
+   mMaxTime(0),
+   mMinTime(std::numeric_limits<long long>::max()),
+   mCount(0),
+   mTotalTime(0) {}
+
+
+void TimeStats::Save(long long ns) {
+   ++mCount;
+   mTotalTime += ns;
+   mMaxTime = std::max(mMaxTime, ns);
+   mMinTime = std::min(mMinTime, ns);
+}
+
+size_t TimeStats::ElapsedSec() {
+   return mStopWatch.ElapsedSec();
+}
+void TimeStats::Flush(std::string& str) {
+   str = {"Count: "};
+   str += std::to_string(mCount)
+          + ", Min time: " + std::to_string(mMinTime)  + " ns"
+          + ", Max time: " + std::to_string(mMaxTime) + " ns : "
+          + std::to_string(mMaxTime / 1000) + " us" +
+          ", Average: " + std::to_string(GetAverage()) + " ns : " + std::to_string(GetAverage() / 1000) + " us";
+   Reset();
+}
+
+
+TimeStats::Metrics TimeStats::Flush() {
+   auto result = std::make_tuple(mMinTime, mMaxTime, mCount, mTotalTime, GetAverage());
+   Reset();
+   return result;
+}
+
+
+long long TimeStats::GetAverage() {
+   if (mCount == 0) {
+      return 0;
+   }
+   return mTotalTime / mCount;
+}
+
+void TimeStats::Reset() {
+   mCount = mMaxTime = mTotalTime = 0;
+   mMinTime = std::numeric_limits<long long>::max();
+   mStopWatch.Restart();
+}

--- a/src/TimeStats.h
+++ b/src/TimeStats.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <string>
+#include <tuple>
+#include "StopWatch.h"
+
+/**
+
+Example usage:
+TimeStats is a easy to use instrumentation tool for measuring how expensive
+function calls are. A typical usage would be to measure many thousands of operations and get the max, min and average time to execute this.
+
+See also "TriggerTimeStats" which reduced coat bloat.
+
+TimeStats adds overhead so it should only be used when comparing relative speed of one operation vs another. It should not be used in production code
+
+TimeStats stats;
+while(thread_loop) {
+   ...
+   { // scope around a function call that we want to instrument
+      TriggerTimeStats trigger(stats);
+      func();
+   } // scope exits and `func` is measured.
+
+
+   if (stats.ElapsedSec() == X) {
+      LOG(INFO) << "Expensive call metrics: " << stats.Flush();
+   }
+} // end loop
+*/
+
+
+class TimeStats {
+ public:
+
+   TimeStats();
+   ~TimeStats() = default;
+
+   void Save(long long ns);
+   void Flush(std::string& str);
+   enum Index { MinTime = 0,
+                MaxTime = 1,
+                Count = 2,
+                TotalTime = 3, 
+                Average = 4
+              };
+
+   using Metrics = std::tuple<long long, long long, long long, long long, long long>;
+   Metrics Flush();
+   size_t ElapsedSec();
+
+ private:
+   void Reset();
+   long long GetAverage();
+
+   long long mMaxTime;
+   long long mMinTime;
+   long long mCount;
+   long long mTotalTime;
+   StopWatch mStopWatch;
+
+
+};

--- a/src/TriggerTimeStats.h
+++ b/src/TriggerTimeStats.h
@@ -1,0 +1,40 @@
+/**
+
+Example usage: 
+TriggerTimeStats is a helper for TimeStats
+It is a scope triggered "save" that makes it easy to use without code bloat. 
+The TriggerTimeStats and TimeStats adds overhead so it should only be used
+when comparing relative speed of one operation vs another. It should not be
+used in production code
+
+TimeStats stats;
+while(thread_loop) {
+   ...
+   { // scope around a function call that we want to instrument
+      TriggerTimeStats trigger(stats);
+      func(); 
+   } // scope exits and `func` is measured. 
+}
+
+
+*/
+#include "TimeStats.h"
+#include "StopWatch.h"
+
+class TriggerTimeStats {
+
+
+ public:
+   TriggerTimeStats(TimeStats& timeStats) : mTimeStats(timeStats) {
+      mStopWatch.Restart();
+   }
+
+   ~TriggerTimeStats() {
+      mTimeStats.Save(mStopWatch.ElapsedNs());
+   }
+
+
+ private:
+   TimeStats& mTimeStats;
+   StopWatch mStopWatch;
+};

--- a/test/TimeStatsTest.cpp
+++ b/test/TimeStatsTest.cpp
@@ -1,0 +1,89 @@
+#include "TimeStatsTest.h"
+#include "StopWatch.h"
+#include "TimeStats.h"
+#include <limits>
+#include <thread>
+#include <chrono>
+
+#include "TriggerTimeStats.h"
+
+namespace {
+   const long long kNanoSecMinFake = 100;
+   const long long kNanoSecMaxFake = 300;
+   const long long kEmpty = 0;
+   const long long kAverage = 200;
+}
+
+TEST_F(TimeStatsTest, StatsEmpty) {
+   TimeStats stats;
+   auto metrics =  stats.Flush();
+   EXPECT_EQ(std::numeric_limits<long long>::max(), std::get<TimeStats::Index::MinTime>(metrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::MaxTime>(metrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::Count>(metrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::TotalTime>(metrics));
+   EXPECT_EQ(0, std::get<TimeStats::Index::Average>(metrics));
+}
+
+TEST_F(TimeStatsTest, StatsEmpty2) {
+   TimeStats stats;
+   std::string metrics = "to be erased";
+   stats.Flush(metrics);
+   std::string expected = "Count: 0, Min time: ";
+   expected += std::to_string(std::numeric_limits<long long>::max());
+   expected += " ns, Max time: 0 ns : 0 us,";
+   expected += " Average: 0 ns : 0 us";
+   EXPECT_EQ(metrics, expected);
+}
+
+
+TEST_F(TimeStatsTest, SimpleSetup) {
+   TimeStats stats;
+   stats.Save(kNanoSecMinFake);
+   stats.Save(kNanoSecMaxFake);
+   auto metrics =  stats.Flush();
+   EXPECT_EQ(kNanoSecMinFake, std::get<TimeStats::Index::MinTime>(metrics));
+   EXPECT_EQ(kNanoSecMaxFake, std::get<TimeStats::Index::MaxTime>(metrics));
+   EXPECT_EQ(2, std::get<TimeStats::Index::Count>(metrics));
+   EXPECT_EQ(kNanoSecMinFake + kNanoSecMaxFake, std::get<TimeStats::Index::TotalTime>(metrics));
+   EXPECT_EQ(kAverage, std::get<TimeStats::Index::Average>(metrics));
+}
+
+TEST_F(TimeStatsTest, SimpleSetup2) {
+   TimeStats stats;
+   long long kNanoSecMinFake = 100;
+   long long kNanoSecMaxFake = 300;
+   stats.Save(kNanoSecMinFake);
+   stats.Save(kNanoSecMaxFake);
+   std::string metrics = "to be erased";
+   stats.Flush(metrics);
+   std::string expected = "Count: 2, Min time: 100";
+   expected += " ns, Max time: 300 ns : 0 us,";
+   expected += " Average: 200 ns : 0 us";
+   EXPECT_EQ(metrics, expected);
+}
+
+
+TEST_F(TimeStatsTest, TimeTrigger1s) {
+   TimeStats stats;
+   using namespace std::chrono_literals;
+   long long counter = 0;
+   while (stats.ElapsedSec() <= 1) {
+      ++counter;
+      {
+         TriggerTimeStats trigger{stats}; // implicit &
+         std::this_thread::sleep_for(1ms);
+      }
+   }
+   auto metrics =  stats.Flush();
+   long long expectedMinNs = 1 * 1000000;
+   EXPECT_GT(std::get<TimeStats::Index::MinTime>(metrics), expectedMinNs);
+
+   auto zeroMetrics = stats.Flush();
+   EXPECT_EQ(std::numeric_limits<long long>::max(), std::get<TimeStats::Index::MinTime>(zeroMetrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::MaxTime>(zeroMetrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::Count>(zeroMetrics));
+   EXPECT_EQ(kEmpty, std::get<TimeStats::Index::TotalTime>(zeroMetrics));
+   EXPECT_EQ(0, std::get<TimeStats::Index::Average>(zeroMetrics));
+}
+
+

--- a/test/TimeStatsTest.h
+++ b/test/TimeStatsTest.h
@@ -1,0 +1,23 @@
+/* 
+ * File:   TimeStatsTest.h
+ * Author: kjell
+ *
+ */
+
+#pragma once
+#include "gtest/gtest.h"
+
+class TimeStatsTest : public ::testing::Test {
+public:
+
+   TimeStatsTest() {
+   };
+protected:
+
+   virtual void SetUp() {
+   };
+
+   virtual void TearDown() {
+   };
+private:
+};


### PR DESCRIPTION
This utility, tightly dependent on StopWatch, is nifty when you want to do comparisons and measurements of how time expensive function calls are. 

Some interesting stats from our `master` branch modified for getting some metrics

Multiple measurements of roughly 6.8 million packets measured each time

**ZMQ Routing Thread Fire to Qosmos Worker**

| Min  | Max | Average |
| ------------- | ------------- | ------------- |
| 2 us  | 25 ms  | 8-15 us |


**Hashing of packets** Multiple measurements of roughly 7 million packets measured each time

| Min  | Max | Average |
| ------------- | ------------- | ------------- |
| 90 ns  | 23 ms  | 0.6 - 1 us |


**FULL packet routing loop (hashing etc) MINUS the "get packets"**
Multiple measurements of roughly 200,000 loops (each 1 packet)

| Min  | Max | Average |
| ------------- | ------------- | ------------- |
| 26 ns (no work)  | 154 ms  | 400 - 600 us |


**Routing thread: Get PACKETS from I/F capture thread**
Multiple measurements of roughly 150, 000 - 200,000 loops 

| Type:  | Min |  Max | Average |  
| ------------- | ------------- | ------------- | ------------- | 
| ZMQ | 6 us   | 23 ms  |  1020 us*|  
| MutexQ |  0.2us | 358ms | 18 ms* |
| Circular lock-free naive synchronized atomics |  1.1 us | 0.5 - 1.3 ms | 2 - 3 us |
| Circular lock-free naive relaxed atomics |  1.1 us | 0.5-1 ms |  1 - 2.5 us
                
**I/F Push to  Routing Thread:**

| Type:  | Min |  Max | Average |  
| ------------- | ------------- | ------------- | ------------- | 
| ZMQ | 7 us   | 36 ms  |  53 us|  
| MutexQ |  01.5us | 32ms | 6 us |
| Circular lock-free naive synchronized atomics |  1.1 us | 6.5 ms | 2 us |
| Circular lock-free naive relaxed atomics |  1 us | 0.9 -1.3 us |  1 us


**Read CHUNK packets from I/F** 
Measured 100,000 times

| Min  | Max | Average |
| ------------- | ------------- | ------------- |
| 97 us   | 65 ms  | 2.8 ms |
